### PR TITLE
Add Sphinx plugin for JSON Schema support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,42 @@
+stoplightio-schema-sphinx
+=========================
+
+This package provides a simple Sphinx extension that automatically adds
+JSON schemas to function and method documentation. Schemas are searched in
+a directory specified by ``json_schema_dir`` in your ``conf.py``.
+
+The file naming convention is::
+
+   <ClassName>.<method>.schema.json
+   <function>.schema.json
+
+When ``autodoc`` processes a function or method it will look for the
+corresponding schema file and append it to the generated documentation.
+
+Generating Schemas
+------------------
+
+Schema files can be produced using the `@stoplight/json-schema-generator`
+package from npm. After installing Node.js and npm run::
+
+   npx -y @stoplight/json-schema-generator --file input.json --schemadir schemas
+
+This will place ``input.schema.json`` inside the ``schemas`` directory which the
+extension can then pick up during documentation builds.
+
+Example
+-------
+
+Add the extension and configure ``json_schema_dir`` in ``conf.py``::
+
+   extensions = [
+       "sphinx.ext.autodoc",
+       "stoplightio_schema_sphinx",
+   ]
+   json_schema_dir = os.path.join(os.path.dirname(__file__), "schemas")
+
+Create ``schemas/MyClass.my_method.schema.json`` and the schema will appear
+in your documentation for ``MyClass.my_method``.
+
+A ``schema_to_rst`` fixture is also provided for tests to convert schema
+files to reStructuredText.

--- a/example/docs/conf.py
+++ b/example/docs/conf.py
@@ -1,0 +1,12 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../src'))
+sys.path.insert(0, os.path.abspath('../../src'))
+
+extensions = ['sphinx.ext.autodoc', 'stoplightio_schema_sphinx']
+
+json_schema_dir = os.path.abspath('../schemas')
+
+autodoc_default_options = {
+    'members': True,
+}

--- a/example/docs/index.rst
+++ b/example/docs/index.rst
@@ -1,0 +1,5 @@
+Example Documentation
+=====================
+
+.. automodule:: example_module
+    :members:

--- a/example/schemas/MyClass.greet.schema.json
+++ b/example/schemas/MyClass.greet.schema.json
@@ -1,0 +1,10 @@
+{
+  "title": "Greeting",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  },
+  "required": ["name"]
+}

--- a/example/schemas/add.schema.json
+++ b/example/schemas/add.schema.json
@@ -1,0 +1,9 @@
+{
+  "title": "AddArguments",
+  "type": "object",
+  "properties": {
+    "a": {"type": "integer"},
+    "b": {"type": "integer"}
+  },
+  "required": ["a", "b"]
+}

--- a/example/src/example_module.py
+++ b/example/src/example_module.py
@@ -1,0 +1,9 @@
+class MyClass:
+    def greet(self, name: str) -> str:
+        """Return greeting message."""
+        return f"Hello, {name}!"
+
+
+def add(a: int, b: int) -> int:
+    """Add two numbers."""
+    return a + b

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "stoplightio-schema-sphinx"
+version = "0.1.0"
+authors = [{ name = "Miskler" }]
+description = "Sphinx extension to include Stoplight.io style JSON schemas"
+readme = "README.rst"
+license = { file = "LICENSE" }
+requires-python = ">=3.8"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Framework :: Sphinx",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "sphinx",
+    "sphinx-testing",
+]
+
+[tool.setuptools]
+packages = ["stoplightio_schema_sphinx"]
+package-dir = {"" = "src"}

--- a/src/stoplightio_schema_sphinx/__init__.py
+++ b/src/stoplightio_schema_sphinx/__init__.py
@@ -1,0 +1,5 @@
+"""Stoplight.io JSON schema support for Sphinx."""
+
+from .sphinx import setup, schema_to_rst, load_schema
+
+__all__ = ["setup", "schema_to_rst", "load_schema"]

--- a/src/stoplightio_schema_sphinx/sphinx.py
+++ b/src/stoplightio_schema_sphinx/sphinx.py
@@ -1,0 +1,52 @@
+"""Sphinx extension for embedding JSON schemas in autodoc documentation."""
+import json
+import os
+from typing import List, Dict, Any, Optional
+
+SCHEMA_LINES_HEADER = ["", "**JSON Schema**", "", ".. code-block:: json", ""]
+
+
+def schema_to_rst(schema: Dict[str, Any]) -> List[str]:
+    """Convert JSON schema dict to rst lines."""
+    return SCHEMA_LINES_HEADER + ["   " + line for line in json.dumps(schema, indent=2).splitlines()] + [""]
+
+
+def load_schema(schema_dir: str, *, class_name: Optional[str], func_name: str) -> Optional[List[str]]:
+    """Load schema file based on class/func names and return rst lines."""
+    if class_name:
+        filename = f"{class_name}.{func_name}.schema.json"
+    else:
+        filename = f"{func_name}.schema.json"
+    path = os.path.join(schema_dir, filename)
+    if not os.path.exists(path):
+        return None
+    with open(path, "r", encoding="utf-8") as f:
+        schema = json.load(f)
+    return schema_to_rst(schema)
+
+
+def process_docstring(app, what, name, obj, options, lines) -> None:
+    schema_dir = app.config.json_schema_dir
+    if not schema_dir:
+        return
+    if what not in {"function", "method"}:
+        return
+    class_name = None
+    func_name = name.split(".")[-1]
+    if what == "method":
+        parts = name.split(".")
+        if len(parts) >= 2:
+            class_name = parts[-2]
+    rst_lines = load_schema(schema_dir, class_name=class_name, func_name=func_name)
+    if rst_lines:
+        lines.extend(rst_lines)
+
+
+def setup(app):
+    app.add_config_value("json_schema_dir", default=None, rebuild="html")
+    app.connect("autodoc-process-docstring", process_docstring)
+    return {
+        "version": "0.1",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1,0 +1,30 @@
+import os
+import json
+from sphinx.application import Sphinx
+from stoplightio_schema_sphinx import schema_to_rst
+
+
+def test_schema_to_rst(tmp_path):
+    schema_path = tmp_path / "func.schema.json"
+    schema = {"type": "object"}
+    schema_path.write_text(json.dumps(schema))
+    rst = schema_to_rst(schema)
+    assert ".. code-block:: json" in "\n".join(rst)
+
+
+def test_sphinx_build(tmp_path):
+    srcdir = tmp_path / "src"
+    os.makedirs(srcdir)
+    (srcdir / "conf.py").write_text(
+        "import os, sys\n"
+        "sys.path.insert(0, os.path.abspath('.'))\n"
+        "extensions=['sphinx.ext.autodoc','stoplightio_schema_sphinx']\n"
+        "json_schema_dir=os.path.abspath('.')\n")
+    (srcdir / "index.rst").write_text(".. autofunction:: module.func\n")
+    (srcdir / "module.py").write_text("def func():\n    \"\"\"Do things.\"\"\"\n")
+    schema = {'type': 'object'}
+    (srcdir / "func.schema.json").write_text(json.dumps(schema))
+    app = Sphinx(str(srcdir), str(srcdir), str(tmp_path/'out'), str(tmp_path/'doctrees'), "html")
+    app.build()
+    html = (tmp_path / 'out' / 'index.html').read_text()
+    assert 'JSON Schema' in html


### PR DESCRIPTION
## Summary
- implement `stoplightio_schema_sphinx` extension
- add example project with schemas
- include tests demonstrating integration
- document usage in `README.rst`
- clarify generation of schema files and 3.8-compatible typing

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861875f67cc832fb8af701b1e618f33